### PR TITLE
Add regression test on Hera based on mini prototype 7.2 with prognostic aerosols

### DIFF
--- a/modulefiles/ufs_hera.intel
+++ b/modulefiles/ufs_hera.intel
@@ -31,5 +31,5 @@ setenv CXX mpiicpc
 setenv FC mpiifort
 setenv CMAKE_Platform hera.intel
 
-# use shared memory and OpenFabrics Alliance (OFA) fabric with Intel MPI to circumvent RDMA-related bug in DAPL.
-setenv I_MPI_FABRICS shm:ofa
+# Intel MPI setting to circumvent RDMA-related bug in DAPL.
+setenv I_MPI_DAPL_UD 1

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -242,7 +242,7 @@ elif [[ $MACHINE_ID = hera.* ]]; then
 
   TASKS_cpl_dflt=200; TPN_cpl_dflt=40; INPES_cpl_dflt=3; JNPES_cpl_dflt=8
   THRD_cpl_dflt=1; WPG_cpl_dflt=6;  MPB_cpl_dflt="0 143"; APB_cpl_dflt="0 149"
-  OPB_cpl_dflt="150 169"; IPB_cpl_dflt="170 179"; WPB_cpl_dflt="180 199"
+  CHM_cpl_dflt="0 143"; OPB_cpl_dflt="150 169"; IPB_cpl_dflt="170 179"; WPB_cpl_dflt="180 199"
   NPROC_ICE_cpl_dflt=10
 
   TASKS_cpl_thrd=120; TPN_cpl_thrd=20; INPES_cpl_thrd=3; JNPES_cpl_thrd=4
@@ -267,7 +267,7 @@ elif [[ $MACHINE_ID = hera.* ]]; then
 
   TASKS_cpl_bmrk=560; TPN_cpl_bmrk=40; INPES_cpl_bmrk=6; JNPES_cpl_bmrk=8
   THRD_cpl_bmrk=1; WPG_cpl_bmrk=24; MPB_cpl_bmrk="0 287"; APB_cpl_bmrk="0 311"
-  OPB_cpl_bmrk="312 431"; IPB_cpl_bmrk="432 479"; WPB_cpl_bmrk="480 559"
+  CHM_cpl_bmrk="0 287"; OPB_cpl_bmrk="312 431"; IPB_cpl_bmrk="432 479"; WPB_cpl_bmrk="480 559"
   NPROC_ICE_cpl_bmrk=48
 
   TASKS_cpl_bmrk_mpi=600; TPN_cpl_bmrk_mpi=40; INPES_cpl_bmrk_mpi=6; JNPES_cpl_bmrk_mpi=8
@@ -1017,6 +1017,8 @@ export NPZ=127
 export NPZP=128
 
 # default resources
+export DOMAINS_STACK_SIZE=3000000
+
 export TASKS=$TASKS_cpl_dflt
 export TPN=$TPN_cpl_dflt
 export INPES=$INPES_cpl_dflt
@@ -1026,6 +1028,7 @@ export WRTTASK_PER_GROUP=$WPG_cpl_dflt
 
 export med_petlist_bounds=$MPB_cpl_dflt
 export atm_petlist_bounds=$APB_cpl_dflt
+export chm_petlist_bounds=$CHM_cpl_dflt
 export ocn_petlist_bounds=$OPB_cpl_dflt
 export ice_petlist_bounds=$IPB_cpl_dflt
 export wav_petlist_bounds=$WPB_cpl_dflt
@@ -1040,6 +1043,7 @@ export DT_THERM_MOM6=3600
 export NEMS_CONFIGURE=nems.configure.cpld_wave.IN
 export med_model=cmeps
 export atm_model=fv3
+export chm_model=gocart
 export ocn_model=mom6
 export ice_model=cice6
 export wav_model=ww3

--- a/tests/fv3_conf/cpld_control_run.IN
+++ b/tests/fv3_conf/cpld_control_run.IN
@@ -129,3 +129,9 @@ if [ $DO_UGWP_V1 = .true. ]; then
   cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT_L127/oro_data_ls* ./INPUT
   cp    @[INPUTDATA_ROOT]/${FV3_DIR}/INPUT_L127/oro_data_ss* ./INPUT
 fi
+
+#prognostic aerosols
+if [ $CPLCHM = .true. ]; then
+  cp      /scratch1/NCEPDEV/nems/Raffaele.Montuoro/emc.nemspara/RT/NEMSfv3gfs/input-data-20211210/GOCART/p7/rc/*.rc .
+  ln -sf  /scratch1/NCEPDEV/nems/Raffaele.Montuoro/emc.nemspara/RT/NEMSfv3gfs/input-data-20211210/GOCART/p7/ExtData .
+fi

--- a/tests/parm/cpld_control.nml.IN
+++ b/tests/parm/cpld_control.nml.IN
@@ -23,7 +23,7 @@ deflate_level=1
 
 &fms_nml
   clock_grain = 'ROUTINE'
-  domains_stack_size = 3000000
+  domains_stack_size = @[DOMAINS_STACK_SIZE]
   print_memory_usage = .false.
 /
 

--- a/tests/parm/diag_table/diag_table_p7.2_template
+++ b/tests/parm/diag_table/diag_table_p7.2_template
@@ -1,0 +1,303 @@
+@[SYEAR]@[SMONTH]@[SDAY].@[SHOUR]Z.@[ATMRES].64bit.non-mono
+@[SYEAR] @[SMONTH] @[SDAY] @[SHOUR] 0 0
+
+"fv3_history",    0,  "hours",  1,  "hours",  "time"
+"fv3_history2d",  0,  "hours",  1,  "hours",  "time"
+######################
+"ocn%4yr%2mo%2dy%2hr",      6,  "hours", 1, "hours", "time", 6, "hours", "1901 1 1 0 0 0"
+"SST%4yr%2mo%2dy",      1,  "days",  1, "days",  "time", 1, "days",  "1901 1 1 0 0 0"
+##############################################
+# static fields
+ "ocean_model", "geolon",      "geolon",      "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolat",      "geolat",      "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolon_c",    "geolon_c",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolat_c",    "geolat_c",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolon_u",    "geolon_u",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolat_u",    "geolat_u",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolon_v",    "geolon_v",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "geolat_v",    "geolat_v",    "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+# "ocean_model", "depth_ocean", "depth_ocean", "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+# "ocean_model", "wet",         "wet",         "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "wet_c",       "wet_c",       "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "wet_u",       "wet_u",       "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "wet_v",       "wet_v",       "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "sin_rot",     "sin_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+ "ocean_model", "cos_rot",     "cos_rot",     "ocn%4yr%2mo%2dy%2hr", "all", .false., "none", 2
+
+# ocean output TSUV and others
+ "ocean_model", "SSH",       "SSH",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "SST",       "SST",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "SSS",       "SSS",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "speed",     "speed",    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "SSU",       "SSU",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "SSV",       "SSV",      "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "frazil",    "frazil",   "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "ePBL_h_ML", "ePBL",     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "MLD_003",   "MLD_003",  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "MLD_0125",  "MLD_0125", "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+
+# save daily SST
+ "ocean_model", "geolon",      "geolon",      "SST%4yr%2mo%2dy", "all", .false., "none", 2
+ "ocean_model", "geolat",      "geolat",      "SST%4yr%2mo%2dy", "all", .false., "none", 2
+ "ocean_model", "SST",         "sst",         "SST%4yr%2mo%2dy", "all", .true.,  "none", 2
+
+# Z-Space Fields Provided for CMIP6 (CMOR Names):
+#===============================================
+ "ocean_model_z","uo","uo"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model_z","vo","vo"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model_z","so","so"      ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model_z","temp","temp"  ,"ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+
+# forcing
+ "ocean_model", "taux",      "taux",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "tauy",      "tauy",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "latent",    "latent",                   "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "sensible",  "sensible",                 "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "SW",        "SW",                       "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "LW",        "LW",                       "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "evap",      "evap",                     "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "lprec",     "lprec",                    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "lrunoff",   "lrunoff",                  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+# "ocean_model", "frunoff",   "frunoff",                  "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "fprec",     "fprec",                    "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "LwLatSens", "LwLatSens",                "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+ "ocean_model", "Heat_PmE",  "Heat_PmE",                 "ocn%4yr%2mo%2dy%2hr","all",.true.,"none",2
+#
+###
+# FV3 variabls needed for NGGPS evaluation
+###
+"gfs_dyn",     "ucomp",       "ugrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "vcomp",       "vgrd",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "sphum",       "spfh",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "temp",        "tmp",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "liq_wat",     "clwmr",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "o3mr",        "o3mr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delp",        "dpres",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "delz",        "delz",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "w",           "dzdt",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_wat",     "icmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "rainwat",     "rwmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "snowwat",     "snmr",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "graupel",     "grle",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
+#"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+#"gfs_dyn",     "rain_nc",     "ntrnc",     "fv3_history",  "all",  .false.,  "none",  2
+
+# chemical tracers advected by FV3
+"gfs_dyn",     "so2",         "so2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "so4",         "so4",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dms",         "dms",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "msa",         "msa",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "bc1",         "bc1",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "bc2",         "bc2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "oc1",         "oc1",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "oc2",         "oc2",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust1",       "dust1",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust2",       "dust2",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust3",       "dust3",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust4",       "dust4",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "dust5",       "dust5",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas1",       "seas1",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas2",       "seas2",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas3",       "seas3",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas4",       "seas4",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "seas5",       "seas5",     "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "nh3",         "nh3",       "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "nh4a",        "nh4a",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an1",      "no3an1",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an2",      "no3an2",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "no3an3",      "no3an3",    "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "pm25",        "pm25",      "fv3_history",    "all",  .false.,  "none",  2
+"gfs_dyn",     "pm10",        "pm10",      "fv3_history",    "all",  .false.,  "none",  2
+
+"gfs_phys",  "ALBDO_ave",     "albdo_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcp_ave",   "cprat_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "cnvprcpb_ave",  "cpratb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcp_ave",   "prate_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "totprcpb_ave",  "prateb_ave",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRF",         "dlwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DLWRFI",        "dlwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRF",         "ulwrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFI",        "ulwrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRF",         "dswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFI",        "dswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRF",         "uswrf_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFI",        "uswrf",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "DSWRFtoa",      "dswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "USWRFtoa",      "uswrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "ULWRFtoa",      "ulwrf_avetoa","fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "gflux_ave",     "gflux_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "hpbl",          "hpbl",        "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "lhtfl_ave",     "lhtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "shtfl_ave",     "shtfl_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "pwat",          "pwatclm",     "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "soilm",         "soilm",       "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_aveclm",   "tcdc_aveclm", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avebndcl", "tcdc_avebndcl",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avehcl",   "tcdc_avehcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avelcl",   "tcdc_avelcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDC_avemcl",   "tcdc_avemcl", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TCDCcnvcl",     "tcdccnvcl",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclt",    "prescnvclt",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PREScnvclb",    "prescnvclb",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehct",   "pres_avehct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avehcb",   "pres_avehcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avehct",   "tmp_avehct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemct",   "pres_avemct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avemcb",   "pres_avemcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avemct",   "tmp_avemct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelct",   "pres_avelct", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "PRES_avelcb",   "pres_avelcb", "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "TEMP_avelct",   "tmp_avelct",  "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "u-gwd_ave",     "u-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "v-gwd_ave",     "v-gwd_ave",   "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dusfc",         "uflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+"gfs_phys",  "dvsfc",         "vflx_ave",    "fv3_history2d",         "all",  .false.,  "none",  2
+#"gfs_phys",  "cnvw",          "cnvcldwat",   "fv3_history2d",         "all",  .false.,  "none",  2
+
+"gfs_phys",    "psurf",       "pressfc",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "u10m",        "ugrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "v10m",        "vgrd10m",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "crain",       "crain",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tprcp",       "tprcp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hgtsfc",      "orog",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "weasd",       "weasd",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "f10m",        "f10m",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "q2m",         "spfh2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "t2m",         "tmp2m",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tsfc",        "tmpsfc",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vtype",       "vtype",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "stype",       "sotyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slmsksfc",    "land",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "vfracsfc",    "veg",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "zorlsfc",     "sfcr",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "uustar",      "fricv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt1",      "soilt1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt2",      "soilt2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt3",      "soilt3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilt4",      "soilt4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw1",      "soilw1"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw2",      "soilw2"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw3",      "soilw3"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "soilw4",      "soilw4"     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_1",       "soill1",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_2",       "soill2",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_3",       "soill3",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slc_4",       "soill4",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "slope",       "sltyp",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnsf",       "alnsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alnwf",       "alnwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvsf",       "alvsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "alvwf",       "alvwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "canopy",      "cnwat",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facsf",       "facsf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "facwf",       "facwf",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffhh",        "ffhh",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "ffmm",        "ffmm",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "fice",        "icec",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "hice",        "icetk",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snoalb",      "snoalb",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmax",      "shdmax",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "shdmin",      "shdmin",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "snowd",       "snod",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tg3",         "tg3",       "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tisfc",       "tisfc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "tref",        "tref",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "z_c",         "zc",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_0",         "c0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "c_d",         "cd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_0",         "w0",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "w_d",         "wd",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xt",          "xt",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xz",          "xz",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "dt_cool",     "dtcool",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xs",          "xs",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xu",          "xu",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xv",          "xv",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xtts",        "xtts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "xzts",        "xzts",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "d_conv",      "dconv",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_sfc",     "qrain",       "qrain",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "acond",        "acond",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cduvb_ave",    "cduvb_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cpofp",        "cpofp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "duvb_ave",     "duvb_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdlf_ave",    "csdlf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_ave",    "csusf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csusf_avetoa", "csusftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csdsf_ave",    "csdsf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_ave",    "csulf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "csulf_avetoa", "csulftoa",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "cwork_ave",    "cwork_aveclm",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evbs_ave",     "evbs_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "evcw_ave",     "evcw_ave",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "fldcp",        "fldcp",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "hgt_hyblev1",  "hgt_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfh_hyblev1", "spfh_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ugrd_hyblev1", "ugrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vgrd_hyblev1", "vgrd_hyblev1",  "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmp_hyblev1",  "tmp_hyblev1",   "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "gfluxi",       "gflux",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "lhtfl",        "lhtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "shtfl",        "shtfl",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr",        "pevpr",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "pevpr_ave",    "pevpr_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sbsno_ave",    "sbsno_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sfexc",        "sfexc",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snohf",        "snohf",         "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "snowc_ave",    "snowc_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmax2m",    "spfhmax_max2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "spfhmin2m",    "spfhmin_min2m", "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmax2m",     "tmax_max2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "tmpmin2m",     "tmin_min2m",    "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "ssrun_acc",    "ssrun_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "sunsd_acc",    "sunsd_acc",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "watr_acc",     "watr_acc",      "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "wilt",         "wilt",          "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vbdsf_ave",    "vbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "vddsf_ave",    "vddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nbdsf_ave",    "nbdsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "nddsf_ave",    "nddsf_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "trans_ave",    "trans_ave",     "fv3_history2d",  "all",  .false.,  "none",  2
+
+"gfs_phys",    "AOD_550",      "aod550",        "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "DU_AOD_550",   "du_aod550",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "SU_AOD_550",   "su_aod550",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "BC_AOD_550",   "bc_aod550",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "OC_AOD_550",   "oc_aod550",     "fv3_history2d",  "all",  .false.,  "none",  2
+"gfs_phys",    "SS_AOD_550",   "ss_aod550",     "fv3_history2d",  "all",  .false.,  "none",  2
+#=============================================================================================
+#
+#====> This file can be used with diag_manager/v2.0a (or higher) <====
+#
+#
+#  FORMATS FOR FILE ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"file_name", output_freq, "output_units", format, "time_units", "long_name",
+#
+#
+#output_freq:  > 0  output frequency in "output_units"
+#              = 0  output frequency every time step
+#              =-1  output frequency at end of run
+#
+#output_units = units used for output frequency
+#               (years, months, days, minutes, hours, seconds)
+#
+#time_units   = units used to label the time axis
+#               (days, minutes, hours, seconds)
+#
+#
+#  FORMAT FOR FIELD ENTRIES (not all input values are used)
+#  ------------------------
+#
+#"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+#
+#time_avg = .true. or .false.
+#
+#packing  = 1  double precision
+#         = 2  float
+#         = 4  packed 16-bit integers
+#         = 8  packed 1-byte (not tested?)

--- a/tests/parm/nems.configure.cpld_aero_wave.IN
+++ b/tests/parm/nems.configure.cpld_aero_wave.IN
@@ -1,0 +1,133 @@
+#############################################
+####  NEMS Run-Time Configuration File  #####
+#############################################
+
+# EARTH #
+EARTH_component_list: MED ATM CHM OCN ICE WAV
+EARTH_attributes::
+  Verbosity = 0
+::
+
+# MED #
+MED_model:                      @[med_model]
+MED_petlist_bounds:             @[med_petlist_bounds]
+::
+
+# ATM #
+ATM_model:                      @[atm_model]
+ATM_petlist_bounds:             @[atm_petlist_bounds]
+ATM_attributes::
+  Verbosity = 0
+  DumpFields = false
+  ProfileMemory = false
+  OverwriteSlice = true
+::
+
+# CHM #
+CHM_model:                      @[chm_model]
+CHM_petlist_bounds:             @[chm_petlist_bounds]
+CHM_attributes::
+  Verbosity = 0
+::
+
+# OCN #
+OCN_model:                      @[ocn_model]
+OCN_petlist_bounds:             @[ocn_petlist_bounds]
+OCN_attributes::
+  Verbosity = 0
+  DumpFields = false
+  ProfileMemory = false
+  OverwriteSlice = true
+  mesh_ocn = @[MESHOCN_ICE]
+::
+
+# ICE #
+ICE_model:                      @[ice_model]
+ICE_petlist_bounds:             @[ice_petlist_bounds]
+ICE_attributes::
+  Verbosity = 0
+  DumpFields = false
+  ProfileMemory = false
+  OverwriteSlice = true
+  mesh_ice = @[MESHOCN_ICE]
+  stop_n = @[RESTART_N]
+  stop_option = nhours
+  stop_ymd = -999
+::
+
+# WAV #
+WAV_model:                      @[wav_model]
+WAV_petlist_bounds:             @[wav_petlist_bounds]
+WAV_attributes::
+  Verbosity = 0
+  OverwriteSlice = false
+::
+
+# CMEPS warm run sequence
+runSeq::
+@@[coupling_interval_slow_sec]
+   MED med_phases_prep_ocn_avg
+   MED -> OCN :remapMethod=redist
+   OCN -> WAV
+   WAV -> OCN :srcMaskValues=1
+   OCN
+   @@[coupling_interval_fast_sec]
+     MED med_phases_prep_atm
+     MED med_phases_prep_ice
+     MED -> ATM :remapMethod=redist
+     MED -> ICE :remapMethod=redist
+     WAV -> ATM :srcMaskValues=1
+     ATM -> WAV
+     ICE -> WAV
+     ATM phase1
+     ATM -> CHM
+     CHM
+     CHM -> ATM
+     ATM phase2
+     ICE
+     WAV
+     ATM -> MED :remapMethod=redist
+     MED med_phases_post_atm
+     ICE -> MED :remapMethod=redist
+     MED med_phases_post_ice
+     MED med_phases_prep_ocn_accum
+   @
+   OCN -> MED :remapMethod=redist
+   MED med_phases_post_ocn
+   MED med_phases_restart_write
+@
+::
+
+# CMEPS variables
+
+DRIVER_attributes::
+::
+
+MED_attributes::
+      ATM_model = @[atm_model]
+      ICE_model = @[ice_model]
+      OCN_model = @[ocn_model]
+      history_n = 1
+      history_option = nhours
+      history_ymd = -999
+      coupling_mode = @[CPLMODE]
+::
+ALLCOMP_attributes::
+      ScalarFieldCount = 2
+      ScalarFieldIdxGridNX = 1
+      ScalarFieldIdxGridNY = 2
+      ScalarFieldName = cpl_scalars
+      start_type = @[RUNTYPE]
+      restart_dir = RESTART/
+      case_name = ufs.cpld
+      restart_n = @[RESTART_N]
+      restart_option = nhours
+      restart_ymd = -999
+      dbug_flag = @[cap_dbug_flag]
+      use_coldstart = @[use_coldstart]
+      use_mommesh = @[use_mommesh]
+      eps_imesh = @[eps_imesh]
+      stop_n = @[FHMAX]
+      stop_option = nhours
+      stop_ymd = -999
+::

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -26,6 +26,10 @@ RUN     | cpld_restart_c384_p7                                                  
 COMPILE | -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1                                                 | - wcoss_cray                            | fv3 |
 RUN     | cpld_debug_p7                                                                                                           | - wcoss_cray                            | fv3 |
 
+# Add aerosols (temporary)
+COMPILE | -DAPP=S2SW -DUFS_GOCART=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1                                           | + hera.intel                            | fv3 |
+RUN     | cpld_bmark_p7_aero                                                                                                      | + hera.intel                            | fv3 |
+
 ###################################################################################################################################################################################
 # PROD tests                                                                                                                                                                      #
 ###################################################################################################################################################################################

--- a/tests/tests/cpld_bmark_p7_aero
+++ b/tests/tests/cpld_bmark_p7_aero
@@ -1,0 +1,154 @@
+#
+#  cpld_bmark_p7_aero test
+#
+export TEST_DESCR="Fully coupled FV3-CCPP-MOM6-CICE-CMEPS-GOCART-WW3 system - C384L127 MX025 - Benchmark P7.2 test"
+
+export CNTL_DIR="cpld_bmark_p7"
+
+export LIST_FILES="sfcf006.nc \
+                   atmf006.nc \
+                   gocart.inst_aod.20130401_0600z.nc4 \
+                   20130401.060000.out_grd.gwes_30m \
+                   20130401.060000.out_pnt.points \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc \
+                   RESTART/MOM.res.nc \
+                   RESTART/MOM.res_1.nc \
+                   RESTART/MOM.res_2.nc \
+                   RESTART/MOM.res_3.nc \
+                   RESTART/iced.2013-04-01-21600.nc \
+                   RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc"
+
+export_fv3
+export_cpl
+
+export SYEAR=2013
+export SMONTH=04
+export SDAY=01
+export SHOUR=00
+export SECS=`expr $SHOUR \* 3600`
+export BMIC=.true.
+
+export DAYS=0.25
+export FHMAX=6
+export RESTART_N=`expr ${FHMAX} - ${FHROT}`
+export RESTART_INTERVAL="${RESTART_N} -1"
+
+export WLCLK=45
+
+export DOMAINS_STACK_SIZE=6000000
+
+export TASKS=$TASKS_cpl_bmrk
+export TPN=$TPN_cpl_bmrk
+export INPES=$INPES_cpl_bmrk
+export JNPES=$JNPES_cpl_bmrk
+export THRD=$THRD_cpl_bmrk
+export WRTTASK_PER_GROUP=$WPG_cpl_bmrk
+
+export med_petlist_bounds=$MPB_cpl_bmrk
+export atm_petlist_bounds=$APB_cpl_bmrk
+export chm_petlist_bounds=$CHM_cpl_bmrk
+export ocn_petlist_bounds=$OPB_cpl_bmrk
+export ice_petlist_bounds=$IPB_cpl_bmrk
+export wav_petlist_bounds=$WPB_cpl_bmrk
+
+# atm/ocn/ice resolution
+export ATMRES=C384
+export NPX=385
+export NPY=385
+export IMO=1536
+export JMO=768
+export OUTPUT_GRID="'gaussian_grid'"
+
+export OCNRES=025
+export ICERES=0.25
+export NX_GLB=1440
+export NY_GLB=1080
+export NPROC_ICE=$NPROC_ICE_cpl_bmrk
+export np2=`expr $NPROC_ICE / 2`
+export BLCKX=`expr $NX_GLB / $np2`
+export BLCKY=`expr $NY_GLB / 2`
+
+# resolution dependent setting
+export CDMBWD=${CDMBWD_c384}
+
+# set component and coupling timesteps
+export DT_ATMOS=300
+export DT_CICE=${DT_ATMOS}
+export DT_DYNAM_MOM6=900
+export DT_THERM_MOM6=1800
+
+export CPLCHM=.true.
+
+# nems.configure
+export NEMS_CONFIGURE=nems.configure.cpld_aero_wave.IN
+export coupling_interval_slow_sec=${DT_THERM_MOM6}
+export coupling_interval_fast_sec=${DT_ATMOS}
+
+# resolution dependent files
+export MOM_INPUT=MOM_input_template_${OCNRES}
+export MESHOCN_ICE=mesh.mx${OCNRES}.nc
+export CICEGRID=grid_cice_NEMS_mx${OCNRES}.nc
+export CICEMASK=kmtu_cice_NEMS_mx${OCNRES}.nc
+export CHLCLIM=seawifs-clim-1997-2010.${NX_GLB}x${NY_GLB}.v20180328.nc
+export FRUNOFF=runoff.daitren.clim.${NX_GLB}x${NY_GLB}.v20180328.nc
+
+export FNALBC="'C384.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C384.facsf.tileX.nc'"
+export FNTG3C="'C384.substrate_temperature.tileX.nc'"
+export FNVEGC="'C384.vegetation_greenness.tileX.nc'"
+export FNVETC="'C384.vegetation_type.tileX.nc'"
+export FNSOTC="'C384.soil_type.tileX.nc'"
+export FNVMNC="'C384.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C384.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C384.slope_type.tileX.nc'"
+export FNABSC="'C384.maximum_snow_albedo.tileX.nc'"
+
+export MOM6_RIVER_RUNOFF=True
+export MOM6_RESTART_SETTING=r
+
+export WW3GRIDLINE="'gwes_30m' 'no' 'CPL:native' 'CPL:native' 'CPL:native' 'no' 'no' 'no' 'no' 'no'  1  1  0.00 1.00  F"
+export WW3RSTDTHR=${FHMAX}
+export DT_2_RST="$(printf "%02d" $(( ${WW3RSTDTHR}*3600 )))"
+export RUN_BEG="${SYEAR}${SMONTH}${SDAY} $(printf "%02d" $(( ${SHOUR}  )))0000"
+export RUN_END="2100${SMONTH}${SDAY} $(printf "%02d" $(( ${SHOUR}  )))0000"
+export OUT_BEG=$RUN_BEG
+export OUT_END=$RUN_END
+export RST_BEG=$RUN_BEG
+export RST_2_BEG=$RUN_BEG
+export RST_END=$RUN_END
+export RST_2_END=$RUN_END
+
+export FV3_RUN=cpld_control_run.IN
+export FIELD_TABLE=field_table_GOCART
+export DIAG_TABLE=diag_table_p7.2_template


### PR DESCRIPTION
This PR adds the `cpld_bmark_p7_aero` regression test based on the mini P7.2 configuration.

This regression test works only on the Hera/Intel platform. It is intended to replace the current `cpld_bmark_p7` regression test as it reflects the final P7.2 configuration including prognostic aerosols. It will also need to be extended to other platforms.

This test required the following input files, which are temporarily located at:
- `/scratch1/NCEPDEV/nems/Raffaele.Montuoro/emc.nemspara/RT/NEMSfv3gfs/input-data-20211210/GOCART/p7/rc/*.rc`
    (GOCART configuration files used in P7.2)

- `/scratch1/NCEPDEV/nems/Raffaele.Montuoro/emc.nemspara/RT/NEMSfv3gfs/input-data-20211210/GOCART/p7/ExtData`
    (GOCART input datasets)

Note also that the CMake flag `-DUFS_GOCART=ON` used in [rt.conf](https://github.com/rmontuoro/ufs-weather-model/blob/996240c8480474b2c2ceffb9acdac339bf410001/tests/rt.conf#L30) file should be added to the UFS `S2S` and `S2SW` CMake apps once testing works on all relevant UFS platforms.