### PR TITLE
updating aerosol settings for p8

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -415,7 +415,7 @@ export CNVCLD=.true.
 export PROGSIGMA=.false.
 
 # Aerosol convective scavenging
-export FSCAV_AERO='"*:0.3","so2:0.0","msa:0.0","dms:0.0","nh3:0.4","nh4:0.6","bc1:0.6","bc2:0.6","dust1:0.6","dust2:0.6","dust3:0.6","dust4:0.6","dust5:0.6","seas1:0.5","seas2:0.5","seas3:0.5","seas4:0.5","seas5:0.5"'
+export FSCAV_AERO='"*:0.3","so2:0.0","msa:0.0","dms:0.0","nh3:0.4","nh4:0.6","bc1:0.6","bc2:0.6","oc1:0.4","oc2:0.4","dust1:0.6","dust2:0.6","dust3:0.6","dust4:0.6","dust5:0.6","seas1:0.5","seas2:0.5","seas3:0.5","seas4:0.5","seas5:0.5"'
 
 # SFC
 export DO_MYJSFC=.false.

--- a/tests/parm/gocart/AERO_ExtData.rc
+++ b/tests/parm/gocart/AERO_ExtData.rc
@@ -9,12 +9,12 @@ TROPP            'Pa'    Y       N                  -            0.0      1.0   
 
 #====== Dust Imports =================================================
 # FENGSHA input files. Note: regridding should be N or E
-DU_CLAY           '1'  Y E           -           none none clayfrac    ExtData/dust/FENGSHA_SOILGRIDS2019_GEFSv12_v1.2.nc
-DU_SAND           '1'  Y E           -           none none sandfrac    ExtData/dust/FENGSHA_SOILGRIDS2019_GEFSv12_v1.2.nc
+DU_CLAY           '1'  Y E           -           none none clayfrac    ExtData/dust/FENGSHA_p81_10km_inputs.nc
+DU_SAND           '1'  Y E           -           none none sandfrac    ExtData/dust/FENGSHA_p81_10km_inputs.nc
 DU_SILT           '1'  Y E           -           none none siltfrac    /dev/null
 DU_SSM            '1'  Y E %y4-%m2-%d2T12:00:00  none none ssm         /dev/null:1.0
-DU_RDRAG          NA   Y N %y4-%m2-%d2t12:00:00  none none albedo_drag ExtData/dust/FENGSHA_Albedo_drag_v1.nc
-DU_UTHRES         '1'  Y E           -           none none uthres      ExtData/dust/randomforestensemble_uthres.nc
+DU_RDRAG          NA   Y N %y4-%m2-%d2t12:00:00  none none albedo_drag ExtData/dust/FENGSHA_p81_10km_inputs.nc
+DU_UTHRES         '1'  Y E           -           none none uthres      ExtData/dust/FENGSHA_p81_10km_inputs.nc
 
 #====== BIOMASS BURNING EMISSIONS =======================================
 

--- a/tests/parm/gocart/DU2G_instance_DU.rc
+++ b/tests/parm/gocart/DU2G_instance_DU.rc
@@ -41,6 +41,6 @@ pressure_lid_in_hPa: 0.01
 emission_scheme: fengsha       # choose among: fengsha, ginoux, k14
 
 # FENGSHA settings
-alpha: 0.04
+alpha: 0.039
 gamma: 0.8
 vertical_to_horizontal_flux_ratio_limit: 2.e-04


### PR DESCRIPTION
- [ x ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [ x ] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ x ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.



## Description

This is to update the RT to mimic the p8 aerosol configuration.  Updates the wet deposition coefficient for organic carbon from `0.3 -> 0.4`.  Updates the dust to use the 10km file that is used within P8c and p8 

File to be copied in RT data folder 

`/scratch1/NCEPDEV/global/glopara/data/gocart_emissions/Dust/FENGSHA_p81_10km_inputs.nc`



